### PR TITLE
Print a delimiter line after printing prediction results

### DIFF
--- a/src/main/java/driver/JavaDriver.java
+++ b/src/main/java/driver/JavaDriver.java
@@ -36,6 +36,7 @@ public class JavaDriver {
                 var results =
                         predService.predictOnProject(sourcePath, false, skipSet);
                 new TypeInferenceService.PredictionResults(results).prettyPrint();
+                System.out.println("DONE");
             } catch (Throwable e) {
                 System.out.println("Got exception: " + e.getMessage());
                 e.printStackTrace();


### PR DESCRIPTION
This allows LambdaNet to be driven reliably from the command line.